### PR TITLE
ci: publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,7 +5,21 @@ on:
     types: [created]
 
 jobs:
+  # Gate: the release must typecheck, lint and pass tests before it can publish.
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+      - run: bun run typecheck
+      - run: bun run lint
+      - run: bun test
+
   publish-npm:
+    needs: verify
     runs-on: ubuntu-latest
     permissions:
       # Required for npm Trusted Publishing (OIDC): lets the job mint an OIDC token

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,12 +7,31 @@ on:
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
+    permissions:
+      # Required for npm Trusted Publishing (OIDC): lets the job mint an OIDC token
+      # so npm can authenticate without a long-lived NPM token.
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
+
+      # Bun runs the build (scripts/build.ts uses Bun.build).
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+
+      # Node provides the npm CLI used to publish via OIDC.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      # Trusted Publishing landed in npm 11.5.1; Node 22 ships an older npm, so upgrade.
+      - run: npm install -g npm@latest
+
       - run: bun install --frozen-lockfile
-      - run: bun publish --access public
-        env:
-          NPM_CONFIG_TOKEN: ${{secrets.npm_token}}
+      - run: bun run build
+
+      # No NODE_AUTH_TOKEN: npm exchanges the OIDC token for short-lived credentials and
+      # attaches build provenance automatically.
+      - run: npm publish --access public


### PR DESCRIPTION
Switch the release workflow from a long-lived NPM token to npm Trusted Publishing (OIDC). bun publish does not support OIDC, so the build stays on Bun while the publish uses the npm CLI (>= 11.5.1) authenticated via OIDC.

- Add `id-token: write` permission so the job can mint an OIDC token
- Use actions/setup-node + `npm install -g npm@latest` for OIDC-capable npm
- Publish with `npm publish` (provenance is attached automatically); drop the NPM_CONFIG_TOKEN secret