### PR TITLE
feat: prettier CLI output via @clack/prompts

### DIFF
--- a/.changeset/pretty-prompts.md
+++ b/.changeset/pretty-prompts.md
@@ -1,0 +1,5 @@
+---
+"@piotar/pkg-sync": minor
+---
+
+Prettier CLI output: route human-mode messages through `@clack/prompts` (framed `list`, boxed notes for `config`/`validate`/`sync`, colored success/warn/error logs) instead of raw `console.log`. JSON mode and the stdout/stderr contract are unchanged; the swallowed update-check error now goes to stderr instead of polluting stdout.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@
 /** pkg-sync CLI entry point — wires the commands into the citty command tree. */
 
 import { defineCommand, runCommand, runMain, showUsage } from "citty";
+import * as p from "@clack/prompts";
 import { PROJECT_NAME } from "./common/appConfig";
 import { addCommand } from "./commands/add";
 import { removeCommand } from "./commands/remove";
@@ -45,7 +46,7 @@ function printError(err: unknown): void {
   } else if (isJsonMode()) {
     process.stderr.write(`${JSON.stringify({ error: message })}\n`);
   } else {
-    console.log(message);
+    p.log.error(message);
   }
 }
 

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,4 +1,5 @@
 import { defineCommand } from "citty";
+import * as p from "@clack/prompts";
 import { getApplicationData } from "../utils/getApplicationData";
 import { getPackageJson } from "../utils/getPackageJson";
 import { ApplicationError } from "../models/ApplicationError";
@@ -31,7 +32,7 @@ export const addCommand = defineCommand({
     if (isJsonMode()) {
       emitJson({ added: name, path: record.path, dir: record.dir });
     } else {
-      console.log(`${name} was added.`);
+      p.log.success(`${name} was added.`);
     }
   },
 });

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,4 +1,5 @@
 import { defineCommand } from "citty";
+import * as p from "@clack/prompts";
 import { type ApplicationConfig, defaultJson, getApplicationData } from "../utils/getApplicationData";
 import { emitJson, isJsonMode } from "../utils/output";
 import { jsonArg } from "./sharedArgs";
@@ -23,9 +24,9 @@ const setCommand = defineCommand({
     if (isJsonMode()) {
       emitJson({ key, value: appData.config[key], changed });
     } else if (changed) {
-      console.log(`Property '${key}' value changed.`);
+      p.log.success(`Property '${key}' value changed.`);
     } else {
-      console.log(`Missing property '${key}' in config`);
+      p.log.warn(`Missing property '${key}' in config`);
     }
   },
 });
@@ -44,11 +45,12 @@ const getCommand = defineCommand({
     if (isJsonMode()) {
       emitJson(key ? { [key]: config[key] } : { ...config });
     } else if (key) {
-      console.log(config[key]);
+      p.log.message(`${key} = ${JSON.stringify(config[key])}`);
     } else {
-      for (const [name, value] of Object.entries(config)) {
-        console.log(name, "=", value);
-      }
+      const body = Object.entries(config)
+        .map(([name, value]) => `${name} = ${JSON.stringify(value)}`)
+        .join("\n");
+      p.note(body, "Config");
     }
   },
 });
@@ -65,7 +67,7 @@ const restoreCommand = defineCommand({
     if (isJsonMode()) {
       emitJson({ config: appData.config });
     } else {
-      console.log("Config was restored to default");
+      p.log.success("Config was restored to default");
     }
   },
 });

--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,4 +1,5 @@
 import { defineCommand } from "citty";
+import * as p from "@clack/prompts";
 import { PROJECT_DATA_FILE_PATH } from "../common/appConfig";
 import { includeDirectoriesRules } from "../common/watchRules";
 import { type ApplicationData, getApplicationData } from "../utils/getApplicationData";
@@ -35,19 +36,22 @@ export const listCommand = defineCommand({
       return;
     }
 
-    console.log("Application data file path:", result.dataFile);
-    console.log("Default watch directories:", result.defaultWatchDirs);
+    p.intro("Registered packages");
+    p.log.info(`Data file: ${result.dataFile}`);
+    p.log.info(`Default watch directories: ${result.defaultWatchDirs.join(", ")}`);
+
     if (result.packages.length === 0) {
-      console.log("There are no packages in the list");
+      p.outro("There are no packages in the list");
       return;
     }
+
     for (const { name, path, dir } of result.packages) {
-      console.log();
-      console.log(green(name));
-      console.log("Path:", path);
+      const lines = [`Path: ${path}`];
       if (dir) {
-        console.log("Custom watch directories:", dir);
+        lines.push(`Custom watch directories: ${dir.join(", ")}`);
       }
+      p.note(lines.join("\n"), green(name));
     }
+    p.outro(`${result.packages.length} package(s)`);
   },
 });

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -50,8 +50,8 @@ export const removeCommand = defineCommand({
       emitJson({ removed, missing });
       return;
     }
-    for (const name of removed) console.log(`${name} was removed.`);
-    for (const name of missing) console.log(`Package '${name}' does not exist in the list`);
+    for (const name of removed) p.log.success(`${name} was removed.`);
+    for (const name of missing) p.log.warn(`Package '${name}' does not exist in the list`);
   },
 });
 

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -42,7 +42,7 @@ export const syncCommand = defineCommand({
 
     const synced = relatedPackages.map(({ name }) => name);
     if (!isJsonMode()) {
-      console.log("Dependencies to synchronization", ...synced);
+      p.note(synced.join("\n"), "Dependencies to synchronize");
     }
 
     const watchers = relatedPackages.map((pkg) => createWatcher(pkg));
@@ -54,6 +54,10 @@ export const syncCommand = defineCommand({
 
     if (isJsonMode()) {
       emitJson({ synced, watch: args.watch });
+    } else if (args.watch) {
+      p.log.info("Watching for changes... (Ctrl+C to stop)");
+    } else {
+      p.log.success("Sync complete");
     }
   },
 });

--- a/src/commands/updateCheck.ts
+++ b/src/commands/updateCheck.ts
@@ -1,4 +1,5 @@
 import { defineCommand } from "citty";
+import * as p from "@clack/prompts";
 import { PROJECT_NAME } from "../common/appConfig";
 import { getLatestVersion, updateConsoleMessage } from "../utils/checkUpdates";
 import { getPackageJson } from "../utils/getPackageJson";
@@ -17,7 +18,7 @@ export const updateCheckCommand = defineCommand({
     if (isJsonMode()) {
       emitJson({ current: packageJson.version, latest, upToDate });
     } else if (upToDate) {
-      console.log("Package is up to date");
+      p.log.success("Package is up to date");
     } else {
       updateConsoleMessage(packageJson, latest);
     }

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -1,4 +1,5 @@
 import { defineCommand } from "citty";
+import * as p from "@clack/prompts";
 import { getPackageJson } from "../utils/getPackageJson";
 import { getRelatedDependencies } from "../utils/getRelatedDependencies";
 import { ApplicationError } from "../models/ApplicationError";
@@ -23,7 +24,7 @@ export const validateCommand = defineCommand({
     if (isJsonMode()) {
       emitJson({ packages });
     } else {
-      console.log("Dependencies found", ...packages);
+      p.note(packages.join("\n"), "Dependencies found");
     }
   },
 });

--- a/src/utils/checkUpdates.ts
+++ b/src/utils/checkUpdates.ts
@@ -53,6 +53,7 @@ export async function checkUpdates(packageJson: PackageJson): Promise<void> {
     appData.updateCheck = now;
     appData.$save();
   } catch (error) {
-    console.log((error as Error)?.message);
+    // Startup check is best-effort; surface failures quietly on stderr, never on stdout.
+    note((error as Error)?.message);
   }
 }


### PR DESCRIPTION
Replace raw console.log in human mode with clack log/note/intro/outro helpers across add, remove, sync, validate, update-check, config and list. JSON mode and the stdout/stderr contract are untouched; the swallowed update-check error now goes to stderr instead of stdout.