### PR TITLE
test: cover unsync package-manager detection and session updates

### DIFF
--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -39,4 +39,24 @@ describe("statusResult", () => {
     const result = statusResult(data, "/two");
     expect(result.map((entry) => entry.path)).toEqual(["/two"]);
   });
+
+  test("returns an empty list when nothing is synced", () => {
+    expect(statusResult(appData({}))).toEqual([]);
+  });
+
+  test("reports several targets, flagging the stale one", async () => {
+    const live = await mkdtemp(join(tmpdir(), "pkg-sync-status-"));
+    tmpDirs.push(live);
+    mkdirSync(join(live, "node_modules"), { recursive: true });
+    const result = statusResult(
+      appData({
+        [live]: { packages: ["a"], syncedAt: 1 },
+        "/gone": { packages: ["b"], syncedAt: 2 },
+      }),
+    );
+    expect(result).toEqual([
+      { path: live, packages: ["a"], syncedAt: 1, stale: false },
+      { path: "/gone", packages: ["b"], syncedAt: 2, stale: true },
+    ]);
+  });
 });

--- a/src/commands/unsync.test.ts
+++ b/src/commands/unsync.test.ts
@@ -1,0 +1,63 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { detectPackageManager, nextSession } from "./unsync";
+
+const tmpDirs: string[] = [];
+
+/** Make a temp dir holding the given lockfiles, and return its path. */
+async function withLockfiles(...lockfiles: string[]): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "pkg-sync-unsync-"));
+  tmpDirs.push(root);
+  for (const name of lockfiles) writeFileSync(join(root, name), "");
+  return root;
+}
+
+afterAll(async () => {
+  await Promise.all(tmpDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe("detectPackageManager", () => {
+  test("recognizes bun from bun.lock", async () => {
+    expect(detectPackageManager(await withLockfiles("bun.lock"))).toBe("bun");
+  });
+
+  test("recognizes bun from bun.lockb", async () => {
+    expect(detectPackageManager(await withLockfiles("bun.lockb"))).toBe("bun");
+  });
+
+  test("recognizes pnpm from pnpm-lock.yaml", async () => {
+    expect(detectPackageManager(await withLockfiles("pnpm-lock.yaml"))).toBe("pnpm");
+  });
+
+  test("recognizes yarn from yarn.lock", async () => {
+    expect(detectPackageManager(await withLockfiles("yarn.lock"))).toBe("yarn");
+  });
+
+  test("defaults to npm when no lockfile is present", async () => {
+    expect(detectPackageManager(await withLockfiles())).toBe("npm");
+  });
+
+  test("prefers bun > pnpm > yarn when several lockfiles coexist", async () => {
+    expect(detectPackageManager(await withLockfiles("bun.lock", "pnpm-lock.yaml", "yarn.lock"))).toBe("bun");
+    expect(detectPackageManager(await withLockfiles("pnpm-lock.yaml", "yarn.lock"))).toBe("pnpm");
+  });
+});
+
+describe("nextSession", () => {
+  test("keeps the remaining packages when a subset is unsynced", () => {
+    const session = { packages: ["a", "b", "c"], syncedAt: 7 };
+    expect(nextSession(session, ["b"])).toEqual({ packages: ["a", "c"], syncedAt: 7 });
+  });
+
+  test("returns null when every package is unsynced", () => {
+    expect(nextSession({ packages: ["a", "b"], syncedAt: 0 }, ["a", "b"])).toBeNull();
+  });
+
+  test("preserves other session fields", () => {
+    const next = nextSession({ packages: ["a", "b"], syncedAt: 42 }, ["a"]);
+    expect(next).toEqual({ packages: ["b"], syncedAt: 42 });
+  });
+});

--- a/src/commands/unsync.ts
+++ b/src/commands/unsync.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 import { defineCommand } from "citty";
 import * as p from "@clack/prompts";
-import { getApplicationData } from "../utils/getApplicationData";
+import { getApplicationData, type SyncSession } from "../utils/getApplicationData";
 import { getPackageJson } from "../utils/getPackageJson";
 import { findPackage } from "../utils/findPackage";
 import { ApplicationError } from "../models/ApplicationError";
@@ -46,12 +46,9 @@ export const unsyncCommand = defineCommand({
     const reinstalled = args.reinstall ? reinstall(target) : false;
 
     // Drop the unsynced packages from the session, removing the target entirely when none remain.
-    const remaining = session.packages.filter((name) => !selected.includes(name));
-    if (remaining.length) {
-      appData.targets[target] = { ...session, packages: remaining };
-    } else {
-      delete appData.targets[target];
-    }
+    const next = nextSession(session, selected);
+    if (next) appData.targets[target] = next;
+    else delete appData.targets[target];
     appData.$save();
 
     if (isJsonMode()) {
@@ -64,6 +61,12 @@ export const unsyncCommand = defineCommand({
     else p.log.info("Skipped reinstall; run your package manager's install to restore.");
   },
 });
+
+/** Drop `selected` from the session; returns the new session, or null when nothing is left. */
+export function nextSession(session: SyncSession, selected: string[]): SyncSession | null {
+  const remaining = session.packages.filter((name) => !selected.includes(name));
+  return remaining.length ? { ...session, packages: remaining } : null;
+}
 
 /** Remove an installed package's directory from the target. Returns whether anything was deleted. */
 function deletePackage(name: string, target: string): boolean {
@@ -82,7 +85,7 @@ function reinstall(target: string): boolean {
 }
 
 /** Pick a package manager from the lockfile present in the target, defaulting to npm. */
-function detectPackageManager(target: string): string {
+export function detectPackageManager(target: string): string {
   if (existsSync(join(target, "bun.lockb")) || existsSync(join(target, "bun.lock"))) return "bun";
   if (existsSync(join(target, "pnpm-lock.yaml"))) return "pnpm";
   if (existsSync(join(target, "yarn.lock"))) return "yarn";


### PR DESCRIPTION
## Context

The `unsync`/`status` feature already landed on `main`, but `unsync` shipped without any tests — despite being the riskiest command in the repo (deletes `node_modules` dirs, spawns a package-manager install, mutates the `targets` registry). This PR backfills that coverage, following the project convention of testing **pure, exported functions** rather than side-effecting `run()` handlers (cf. `statusResult`, `partitionRemovals`).

## Changes

- **`unsync.ts`** — small refactor for testability:
  - `export` on `detectPackageManager`
  - new pure `nextSession(session, selected)` helper replacing the inline session-update logic in `run()` (what stays in the session / when to drop the target entry)
- **`unsync.test.ts`** (new) — covers lockfile → package-manager detection (bun `.lock`/`.lockb`, pnpm, yarn, npm default, priority when several coexist) and `nextSession` (subset, full unsync → `null`, field preservation)
- **`status.test.ts`** — fills `statusResult` gaps: empty targets and multiple mixed stale/live targets

## Verification

- `bun test` → 39 pass / 0 fail (was 28)
- `bun run typecheck` and `bun run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)