### PR TITLE
feat: expose package as a Claude Code plugin

### DIFF
--- a/.changeset/claude-plugin-manifest.md
+++ b/.changeset/claude-plugin-manifest.md
@@ -1,0 +1,5 @@
+---
+"@piotar/pkg-sync": minor
+---
+
+Ship a Claude Code plugin manifest (`.claude-plugin/plugin.json`) that exposes the bundled `SKILL.md` as a `pkg-sync` skill, so the package can be loaded directly with `claude --plugin-dir node_modules/@piotar/pkg-sync` (or symlinked into `~/.claude/skills`). The manifest is now published with the package, and the README documents how to wire it up.

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
+  "name": "pkg-sync",
+  "version": "2.3.0",
+  "description": "Mirror a locally-developed npm package into another project's node_modules (no symlinks, no package.json edits) when testing unpublished local changes across separate repos.",
+  "author": {
+    "name": "Piotr Tarasiuk"
+  },
+  "homepage": "https://github.com/piotar/pkg-sync",
+  "repository": "https://github.com/piotar/pkg-sync.git",
+  "license": "MIT",
+  "keywords": [
+    "cli",
+    "sync packages",
+    "dev-tool"
+  ],
+  "skills": [
+    "./"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -89,6 +89,22 @@ The output contract:
 
 A [`SKILL.md`](./SKILL.md) (agentskills.io format) ships with the package so the tool can be taught to AI agents and installed via a skill manager.
 
+### Claude Code plugin
+
+The package doubles as a [Claude Code](https://docs.claude.com/en/docs/claude-code) plugin — a [`.claude-plugin/plugin.json`](./.claude-plugin/plugin.json) manifest exposes the bundled `SKILL.md` as a `pkg-sync` skill. Load it straight from `node_modules` (no separate install):
+
+```sh
+claude --plugin-dir node_modules/@piotar/pkg-sync     # per-session
+```
+
+To make the skill available globally instead, symlink the installed package into your skills directory — it then auto-loads in every session:
+
+```sh
+ln -s "$(npm root -g)/@piotar/pkg-sync" ~/.claude/skills/pkg-sync
+```
+
+Either way Claude gains a `pkg-sync` skill that knows when and how to mirror your local package into another project.
+
 # Commands
 
 Run `pkg-sync <command> --help` for the full, up-to-date options of any command.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "files": [
         "dist",
         "README.md",
-        "SKILL.md"
+        "SKILL.md",
+        ".claude-plugin"
     ],
     "engines": {
         "node": ">=22.0.0"


### PR DESCRIPTION
Add a .claude-plugin/plugin.json manifest that surfaces the bundled SKILL.md as a `pkg-sync` skill, include it in the published files, and document loading it via --plugin-dir or a ~/.claude/skills symlink.